### PR TITLE
feat: add fold-based narrowing with :Narrowing fold command

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ use {
 - `:Narrowing quit` - Close narrowed buffer without saving
 - `:Narrowing window` - Narrow current window's visible content
 - `:Narrowing last` - Re-narrow the last narrowed region
+- `:Narrowing fold` - Narrow the fold range at cursor position
 
 #### Range Support
 - `:10,20Narrowing` - Narrow lines 10-20
@@ -117,6 +118,7 @@ All functionality is available through the unified `:Narrowing` command:
 | `:Narrowing quit` | Close narrowed buffer without saving |
 | `:Narrowing window` | Narrow current window's visible content |
 | `:Narrowing last` | Re-narrow the last narrowed region |
+| `:Narrowing fold` | Narrow the fold range at cursor position |
 
 ### Examples
 
@@ -136,9 +138,28 @@ All functionality is available through the unified `:Narrowing` command:
 " Re-narrow last region
 :Narrowing last
 
+" Narrow fold at cursor position
+:Narrowing fold
+
 " Open in current window (bang modifier)
 :Narrowing! window
 ```
+
+### Fold Narrowing
+
+The `:Narrowing fold` command detects and narrows fold ranges intelligently:
+
+1. **Closed folds**: If cursor is on a closed fold, narrows that fold range
+2. **Open folds**: If cursor is in a foldable region, detects the logical block
+3. **Indentation-based**: Falls back to indentation-based block detection
+4. **Smart detection**: Works with various fold methods (manual, indent, syntax, etc.)
+
+This is particularly useful for:
+- Function definitions
+- Class definitions  
+- Code blocks
+- Configuration sections
+- Any logically grouped content
 
 ## Keymaps
 

--- a/plugin/narrowing.lua
+++ b/plugin/narrowing.lua
@@ -29,10 +29,12 @@ vim.api.nvim_create_user_command("Narrowing", function(opts)
     narrowing.narrow_window(opts.bang)
   elseif subcommand == "last" then
     narrowing.narrow_last(opts.bang)
+  elseif subcommand == "fold" then
+    narrowing.narrow_fold(opts.bang)
   else
     vim.api.nvim_err_writeln("Unknown subcommand: " .. subcommand)
     vim.api.nvim_echo({
-      {"Usage: :Narrowing [narrow|write|quit|window|last]", "Normal"}
+      {"Usage: :Narrowing [narrow|write|quit|window|last|fold]", "Normal"}
     }, false, {})
   end
 end, { 
@@ -40,7 +42,7 @@ end, {
   bang = true,
   nargs = "?",
   complete = function(_, _, _)
-    return { "narrow", "write", "quit", "window", "last" }
+    return { "narrow", "write", "quit", "window", "last", "fold" }
   end,
 })
 


### PR DESCRIPTION
- Add M.get_fold_range() function to detect fold ranges at cursor position
- Support both closed and open folds with intelligent detection
- Fall back to indentation-based block detection when no folds exist
- Add M.narrow_fold() function to narrow detected fold ranges
- Add 'fold' subcommand to :Narrowing command with tab completion
- Provide visual feedback showing detected fold range and line count
- Preserve original fold settings during detection process
- Add comprehensive documentation for fold narrowing feature

This enables users to easily narrow logical code blocks, functions, classes, and other foldable content with a simple :Narrowing fold command.